### PR TITLE
Add modular Enspire data processing program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Enspire Column Plots
+
+Ten projekt zawiera zestaw modułów upraszczających pracę z danymi z czytnika EnSpire. Każdy moduł to osobny plik Pythona.
+
+## Moduły
+
+- `sample_mapper_generator.py` – kreator nazw prób oraz narzędzie do tworzenia pliku mapowania prób na studzienki.
+- `mappings_assigner.py` – przypisuje pliki mapowań do plików wejściowych.
+- `data_generator.py` – generuje uporządkowane dane na podstawie plików wejściowych i mapowania.
+- `data_analyser.py` – oblicza statystyki i (opcjonalnie) stosunki między pomiarami.
+- `interactive_plot_selector.py` – prosty interaktywny wykres środków i odchyleń standardowych.
+- `main.py` – menu łączące działanie wszystkich modułów.
+
+Wszystkie komunikaty diagnostyczne są wyświetlane na konsoli oraz zapisywane w pliku `logs/program.log`.
+
+## Używanie
+
+Uruchom `python3 main.py` i postępuj zgodnie z instrukcjami w menu. Poszczególne katalogi (`input`, `mappings`, `data`, `configs`, `logs`) są tworzone automatycznie.
+

--- a/data_analyser.py
+++ b/data_analyser.py
@@ -1,0 +1,99 @@
+import csv
+import os
+import statistics
+from logger_setup import logger
+
+DATA_DIR = 'data'
+
+
+def read_data(path):
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        rows = [dict(row) for row in reader]
+    return rows
+
+
+def write_data(path, rows, fieldnames):
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def analyze_file(path):
+    logger.info('Analyzing %s', path)
+    rows = read_data(path)
+    if not rows:
+        logger.warning('No data in %s', path)
+        return
+    meas_types = sorted(set(r['Measurement'] for r in rows))
+    logger.debug('Measurement types: %s', meas_types)
+    if len(meas_types) == 1:
+        m = meas_types[0]
+        by_sample = {}
+        for r in rows:
+            sample = r['Sample']
+            value = float(r['Value'])
+            by_sample.setdefault(sample, []).append(value)
+        stats = {s:(statistics.mean(v), statistics.stdev(v) if len(v)>1 else 0.0) for s,v in by_sample.items()}
+        for r in rows:
+            mean, std = stats[r['Sample']]
+            r['Mean'] = f'{mean:.4f}'
+            r['Std'] = f'{std:.4f}'
+        out_path = path.replace('.csv','_analysed.csv')
+        fieldnames = list(rows[0].keys())
+        write_data(out_path, rows, fieldnames)
+        logger.info('Saved analysed data to %s', out_path)
+    elif len(meas_types) == 2:
+        num = input(f'Podaj licznik {meas_types}: ')
+        den = input(f'Podaj mianownik {meas_types}: ')
+        if num not in meas_types or den not in meas_types:
+            logger.error('Niepoprawne nazwy pomiarów')
+            return
+        # create mapping for denominator values
+        denom_map = {}
+        for r in rows:
+            if r['Measurement'] == den:
+                key = (r['Sample'], r['Plate'], r['Row'], r['Column'])
+                denom_map[key] = float(r['Value'])
+        ratio_values = {}
+        for r in rows:
+            if r['Measurement'] == num:
+                key = (r['Sample'], r['Plate'], r['Row'], r['Column'])
+                denom = denom_map.get(key)
+                if denom is not None and float(denom) != 0:
+                    ratio = float(r['Value']) / denom
+                    r['Denominator_Sample'] = r['Sample']
+                    r['Denominator_Plate'] = r['Plate']
+                    r['Denominator_Row'] = r['Row']
+                    r['Denominator_Column'] = r['Column']
+                    r['Denominator_Well'] = r['Well']
+                    r['Denominator_Measurement'] = den
+                    r['Denominator_Value'] = denom
+                    r['Ratio'] = ratio
+                    ratio_values.setdefault(r['Sample'], []).append(ratio)
+                else:
+                    r['Ratio'] = ''
+        ratio_stats = {s:(statistics.mean(v), statistics.stdev(v) if len(v)>1 else 0.0) for s,v in ratio_values.items()}
+        for r in rows:
+            if r['Measurement'] == num and r['Ratio'] != '':
+                mean, std = ratio_stats[r['Sample']]
+                r['Ratio_Mean'] = f'{mean:.4f}'
+                r['Ratio_Std'] = f'{std:.4f}'
+        out_path = path.replace('.csv','_analysed.csv')
+        fieldnames = list(rows[0].keys())
+        if 'Ratio_Mean' in rows[0]:
+            fieldnames.extend(['Ratio_Mean','Ratio_Std'])
+        write_data(out_path, rows, fieldnames)
+        logger.info('Saved analysed data to %s', out_path)
+    else:
+        logger.error('Nieobługiwane liczba typów pomiarów: %s', meas_types)
+
+
+def analyze_all():
+    files = [f for f in os.listdir(DATA_DIR) if f.endswith('_data.csv')]
+    for f in files:
+        analyze_file(os.path.join(DATA_DIR, f))
+
+if __name__ == '__main__':
+    analyze_all()

--- a/data_generator.py
+++ b/data_generator.py
@@ -1,0 +1,74 @@
+import csv
+import os
+from logger_setup import logger
+
+DATA_DIR = 'data'
+MAPPING_DIR = 'mappings'
+
+os.makedirs(DATA_DIR, exist_ok=True)
+
+
+def read_mapping(path):
+    logger.debug('Reading mapping %s', path)
+    mapping = {}
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        cols = next(reader)[1:]
+        for row in reader:
+            if not row:
+                continue
+            row_label = row[0]
+            for c, sample in zip(cols, row[1:]):
+                well = f'{row_label}{c}'
+                mapping[well] = sample.strip()
+    return mapping
+
+
+def parse_input(path):
+    logger.debug('Parsing input file %s', path)
+    results = []
+    with open(path, encoding='utf-8') as f:
+        lines = [line.strip() for line in f]
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith('Results for'):
+            meas = line.split('Results for')[1].split('-')[0].strip()
+            logger.debug('Found measurement %s', meas)
+            i += 2  # skip header
+            for r in range(8):
+                parts = lines[i].split(',')
+                row_label = parts[0]
+                values = parts[2:14]
+                for c_idx, val in enumerate(values, start=1):
+                    if val:
+                        try:
+                            value = float(val)
+                        except ValueError:
+                            logger.warning('Invalid value %s in %s', val, path)
+                            continue
+                        results.append((row_label, c_idx, meas, value))
+                i += 1
+            continue
+        i += 1
+    return results
+
+
+def generate_data(input_file, mapping_file):
+    logger.info('Generating data from %s with mapping %s', input_file, mapping_file)
+    mapping = read_mapping(mapping_file)
+    data = parse_input(input_file)
+    plate_name = os.path.splitext(os.path.basename(input_file))[0]
+    out_path = os.path.join(DATA_DIR, plate_name + '_data.csv')
+    with open(out_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(['Sample','Plate','Row','Column','Well','Measurement','Value'])
+        for row_label, col_idx, meas, value in data:
+            well = f'{row_label}{col_idx:02d}'
+            sample = mapping.get(well, '')
+            writer.writerow([sample, plate_name, row_label, col_idx, well, meas, value])
+    logger.info('Saved data to %s', out_path)
+    return out_path
+
+if __name__ == '__main__':
+    print('Ten moduł powinien być użyty poprzez main.py')

--- a/interactive_plot_selector.py
+++ b/interactive_plot_selector.py
@@ -1,0 +1,72 @@
+import tkinter as tk
+from tkinter import ttk, colorchooser
+import os
+import csv
+import matplotlib.pyplot as plt
+from logger_setup import logger
+
+DATA_DIR = 'data'
+CONFIG_DIR = 'configs'
+
+os.makedirs(CONFIG_DIR, exist_ok=True)
+
+class PlotSelector:
+    def __init__(self):
+        logger.info('Initializing PlotSelector')
+        self.data = self._load_data()
+        self.root = tk.Tk()
+        self.root.title('Interactive Plot Selector')
+        self.selected = []
+        self._build_gui()
+
+    def _load_data(self):
+        logger.debug('Loading analysed data')
+        data = {}
+        for fname in os.listdir(DATA_DIR):
+            if fname.endswith('_analysed.csv'):
+                with open(os.path.join(DATA_DIR, fname), newline='', encoding='utf-8') as f:
+                    reader = csv.DictReader(f)
+                    for row in reader:
+                        sample = row['Sample']
+                        mean = row.get('Ratio_Mean') or row.get('Mean')
+                        std = row.get('Ratio_Std') or row.get('Std')
+                        if mean is None:
+                            continue
+                        data.setdefault(sample, {'mean':float(mean), 'std':float(std) if std else 0.0})
+        logger.debug('Loaded samples: %s', list(data.keys()))
+        return data
+
+    def _build_gui(self):
+        listbox = tk.Listbox(self.root, selectmode=tk.MULTIPLE)
+        for s in sorted(self.data.keys()):
+            listbox.insert(tk.END, s)
+        listbox.pack(side=tk.LEFT, fill=tk.Y, padx=5, pady=5)
+        self.listbox = listbox
+        btn_plot = ttk.Button(self.root, text='Rysuj', command=self.draw_plot)
+        btn_plot.pack(side=tk.LEFT, padx=5)
+
+    def draw_plot(self):
+        selections = [self.listbox.get(i) for i in self.listbox.curselection()]
+        if not selections:
+            return
+        means = [self.data[s]['mean'] for s in selections]
+        stds = [self.data[s]['std'] for s in selections]
+        colors = []
+        for s in selections:
+            color = colorchooser.askcolor(title=f'Kolor dla {s}')[1]
+            if not color:
+                color = 'blue'
+            colors.append(color)
+        plt.figure(figsize=(10,6))
+        plt.bar(range(len(selections)), means, yerr=stds, color=colors, tick_label=selections)
+        plt.xticks(rotation=45)
+        plt.tight_layout()
+        plt.show()
+
+    def run(self):
+        logger.info('Running PlotSelector GUI')
+        self.root.mainloop()
+
+if __name__ == '__main__':
+    app = PlotSelector()
+    app.run()

--- a/logger_setup.py
+++ b/logger_setup.py
@@ -1,0 +1,18 @@
+import logging
+import os
+
+LOG_DIR = 'logs'
+LOG_FILE = os.path.join(LOG_DIR, 'program.log')
+
+os.makedirs(LOG_DIR, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE, encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
+
+logger = logging.getLogger('EnspireProgram')

--- a/main.py
+++ b/main.py
@@ -1,0 +1,73 @@
+import os
+import shutil
+from logger_setup import logger
+import sample_mapper_generator
+import mappings_assigner
+import data_generator
+import data_analyser
+import interactive_plot_selector
+
+ROOT_DIR = os.getcwd()
+INPUT_DIR = 'input'
+MAPPING_DIR = 'mappings'
+DATA_DIR = 'data'
+CONFIG_DIR = 'configs'
+
+for d in [INPUT_DIR, MAPPING_DIR, DATA_DIR, CONFIG_DIR]:
+    os.makedirs(d, exist_ok=True)
+
+
+def copy_input_files(paths):
+    for p in paths:
+        dst = os.path.join(INPUT_DIR, os.path.basename(p))
+        if not os.path.exists(dst):
+            shutil.copy(p, dst)
+            logger.info('Copied %s to %s', p, dst)
+
+
+def main_menu():
+    while True:
+        print('\nWybierz opcję:')
+        print('1 - Generator mappingu')
+        print('2 - Przypisz mappingi do plików')
+        print('3 - Generuj dane')
+        print('4 - Analiza danych')
+        print('5 - Interaktywny wykres')
+        print('0 - Zakończ')
+        choice = input('> ')
+        if choice == '1':
+            app = sample_mapper_generator.SampleMapperGenerator()
+            app.run()
+        elif choice == '2':
+            assigner = mappings_assigner.MappingAssigner()
+            pairs = assigner.run()
+            if pairs:
+                copy_input_files([p[0] for p in pairs])
+                with open('mapping_pairs.txt', 'w', encoding='utf-8') as f:
+                    for p in pairs:
+                        f.write(f'{p[0]};{p[1]}\n')
+        elif choice == '3':
+            if not os.path.exists('mapping_pairs.txt'):
+                print('Brak przypisanych plików. Najpierw użyj opcji 2.')
+                continue
+            with open('mapping_pairs.txt', encoding='utf-8') as f:
+                pairs = [line.strip().split(';') for line in f if line.strip()]
+            for input_file, mapping_file in pairs:
+                try:
+                    data_generator.generate_data(input_file, mapping_file)
+                except Exception as e:
+                    logger.exception('Błąd podczas generowania danych: %s', e)
+            print('Generowanie danych zakończone')
+        elif choice == '4':
+            data_analyser.analyze_all()
+            print('Analiza zakończona')
+        elif choice == '5':
+            app = interactive_plot_selector.PlotSelector()
+            app.run()
+        elif choice == '0':
+            break
+        else:
+            print('Nieznana opcja')
+
+if __name__ == '__main__':
+    main_menu()

--- a/mappings_assigner.py
+++ b/mappings_assigner.py
@@ -1,0 +1,86 @@
+import tkinter as tk
+from tkinter import ttk, filedialog, messagebox
+import os
+from logger_setup import logger
+
+MAPPING_DIR = 'mappings'
+INPUT_DIR = 'input'
+
+class MappingAssigner:
+    def __init__(self):
+        logger.info('Initializing MappingAssigner')
+        os.makedirs(MAPPING_DIR, exist_ok=True)
+        os.makedirs(INPUT_DIR, exist_ok=True)
+        self.root = tk.Tk()
+        self.root.title('Mappings Assigner')
+        self.file_rows = []
+        self._build_gui()
+
+    def _build_gui(self):
+        select_btn = ttk.Button(self.root, text='Wybierz pliki wejściowe', command=self.choose_files)
+        select_btn.pack(pady=5)
+        self.table = ttk.Frame(self.root)
+        self.table.pack(padx=10, pady=10)
+        finish_btn = ttk.Button(self.root, text='Zatwierdź', command=self.finish)
+        finish_btn.pack(pady=5)
+
+    def choose_files(self):
+        files = filedialog.askopenfilenames(initialdir=INPUT_DIR, filetypes=[('CSV','*.csv')])
+        if not files:
+            return
+        for widget in self.table.winfo_children():
+            widget.destroy()
+        self.file_rows = []
+        for i, f in enumerate(files):
+            row_frame = ttk.Frame(self.table)
+            row_frame.grid(row=i, column=0, pady=2)
+            lbl = ttk.Label(row_frame, text=os.path.basename(f))
+            lbl.grid(row=0, column=0)
+            mapping_var = tk.StringVar()
+            option = ttk.Combobox(row_frame, textvariable=mapping_var, values=self._mapping_files())
+            option.grid(row=0, column=1)
+            btn_edit = ttk.Button(row_frame, text='Edytuj', command=lambda path=f, var=mapping_var: self.edit_mapping(path, var))
+            btn_edit.grid(row=0, column=2)
+            self.file_rows.append({'file':f, 'var':mapping_var, 'widget':row_frame})
+        logger.debug('Selected files: %s', files)
+
+    def _mapping_files(self):
+        files = [f for f in os.listdir(MAPPING_DIR) if f.endswith('.csv')]
+        return files
+
+    def edit_mapping(self, path, var):
+        fname = filedialog.askopenfilename(initialdir=MAPPING_DIR, filetypes=[('CSV','*.csv')])
+        if not fname:
+            return
+        var.set(os.path.basename(fname))
+        logger.debug('Assigned mapping %s to %s', fname, path)
+        # For editing we just open using sample_mapper_generator if needed
+        messagebox.showinfo('Info', 'Aby edytować plik mappingu użyj modułu sample-mapper-generator')
+
+    def finish(self):
+        self.pairs = []
+        for row in self.file_rows:
+            mapping_name = row['var'].get()
+            if not mapping_name:
+                messagebox.showerror('Błąd', f'Brak mappingu dla {row["file"]}')
+                return
+            mapping_path = os.path.join(MAPPING_DIR, mapping_name)
+            if not os.path.exists(mapping_path):
+                messagebox.showerror('Błąd', f'Mapping {mapping_path} nie istnieje')
+                return
+            self.pairs.append((row['file'], mapping_path))
+        if not self.pairs:
+            messagebox.showerror('Błąd', 'Brak plików do przypisania')
+            return
+        logger.info('Mappings assigned: %s', self.pairs)
+        self.root.quit()
+
+    def run(self):
+        logger.info('Running MappingAssigner GUI')
+        self.root.mainloop()
+        return getattr(self, 'pairs', [])
+
+if __name__ == '__main__':
+    assigner = MappingAssigner()
+    pairs = assigner.run()
+    print('Pairs:', pairs)

--- a/sample_mapper_generator.py
+++ b/sample_mapper_generator.py
@@ -1,0 +1,142 @@
+import tkinter as tk
+from tkinter import ttk, messagebox, filedialog
+from itertools import product
+import csv
+import os
+from logger_setup import logger
+
+MAPPING_DIR = 'mappings'
+
+class SampleMapperGenerator:
+    def __init__(self):
+        logger.info('Initializing SampleMapperGenerator')
+        os.makedirs(MAPPING_DIR, exist_ok=True)
+        self.root = tk.Tk()
+        self.root.title('Sample Mapper Generator')
+        self.positions = []
+        self.position_frames = []
+        self.names = []
+        self._build_variant_editor()
+
+    def _build_variant_editor(self):
+        logger.debug('Building variant editor')
+        editor_frame = ttk.Frame(self.root)
+        editor_frame.pack(padx=10, pady=10)
+        self.editor_frame = editor_frame
+        self._add_position()
+        gen_button = ttk.Button(self.root, text='Generuj nazwy', command=self.generate_names)
+        gen_button.pack(pady=5)
+        self.names_list = tk.Listbox(self.root, height=10, width=40)
+        self.names_list.pack(pady=5)
+        mapping_button = ttk.Button(self.root, text='Stwórz mapping', command=self.create_mapping)
+        mapping_button.pack(pady=5)
+
+    def _add_position(self):
+        pos_index = len(self.positions)
+        frame = ttk.Frame(self.editor_frame)
+        frame.grid(row=0, column=pos_index, padx=5)
+        entry = ttk.Entry(frame, width=6)
+        entry.pack(pady=2)
+        self.positions.append([entry])
+        btn_add_variant = ttk.Button(frame, text='+ wariant', command=lambda f=frame: self._add_variant(f))
+        btn_add_variant.pack(pady=2)
+        btn_add_position = ttk.Button(frame, text='+ pozycja', command=self._add_position)
+        btn_add_position.pack(pady=2)
+        self.position_frames.append(frame)
+        logger.debug('Added position %s', pos_index)
+
+    def _add_variant(self, frame):
+        entry = ttk.Entry(frame, width=6)
+        entry.pack(pady=2)
+        index = self.position_frames.index(frame)
+        self.positions[index].append(entry)
+        logger.debug('Added variant to position %s', index)
+
+    def generate_names(self):
+        logger.info('Generating names')
+        variants = []
+        for idx, variant_entries in enumerate(self.positions):
+            variant_list = [e.get().strip() for e in variant_entries if e.get().strip()]
+            if not variant_list:
+                messagebox.showerror('Błąd', f'Pozycja {idx+1} nie ma wariantów')
+                return
+            variants.append(variant_list)
+        self.names = [''.join(p) for p in product(*variants)]
+        logger.debug('Generated names: %s', self.names)
+        self.names_list.delete(0, tk.END)
+        for name in self.names:
+            self.names_list.insert(tk.END, name)
+
+    def create_mapping(self):
+        if not self.names:
+            messagebox.showerror('Błąd', 'Najpierw wygeneruj nazwy')
+            return
+        MappingWindow(self.names)
+
+    def run(self):
+        logger.info('Running SampleMapperGenerator GUI')
+        self.root.mainloop()
+
+class MappingWindow:
+    def __init__(self, samples):
+        logger.info('Opening MappingWindow')
+        self.samples = samples
+        self.mapping = {}
+        self.top = tk.Toplevel()
+        self.top.title('Mapowanie prób')
+        self.sample_list = tk.Listbox(self.top)
+        for s in samples:
+            self.sample_list.insert(tk.END, s)
+        self.sample_list.grid(row=0, column=0, rowspan=9, padx=5, pady=5)
+        grid_frame = ttk.Frame(self.top)
+        grid_frame.grid(row=0, column=1, padx=5, pady=5)
+        self.buttons = {}
+        rows = 'ABCDEFGH'
+        cols = [f'{i:02d}' for i in range(1,13)]
+        for r_idx, r in enumerate(rows):
+            for c_idx, c in enumerate(cols):
+                well = f'{r}{c}'
+                btn = ttk.Button(grid_frame, text=well, width=8,
+                                 command=lambda w=well: self.assign_sample(w))
+                btn.grid(row=r_idx, column=c_idx, padx=1, pady=1)
+                self.buttons[well] = btn
+        save_btn = ttk.Button(self.top, text='Zapisz mapping', command=self.save_mapping)
+        save_btn.grid(row=1, column=0, pady=5)
+
+    def assign_sample(self, well):
+        selection = self.sample_list.curselection()
+        if not selection:
+            messagebox.showerror('Błąd', 'Nie wybrano próby')
+            return
+        sample = self.sample_list.get(selection)
+        self.mapping[well] = sample
+        self.buttons[well].config(text=sample)
+        logger.debug('Assigned %s to %s', sample, well)
+
+    def save_mapping(self):
+        if len(self.mapping) != 96:
+            if not messagebox.askyesno('Potwierdzenie', 'Nie wszystkie studzienki zmapowane. Czy kontynuować?'):
+                return
+        filename = filedialog.asksaveasfilename(defaultextension='.csv', initialdir=MAPPING_DIR,
+                                                filetypes=[('CSV','*.csv')])
+        if not filename:
+            return
+        logger.info('Saving mapping to %s', filename)
+        rows = 'ABCDEFGH'
+        cols = [f'{i:02d}' for i in range(1,13)]
+        with open(filename, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow([''] + cols)
+            for r in rows:
+                row = [r]
+                for c in cols:
+                    well = f'{r}{c}'
+                    row.append(self.mapping.get(well, ''))
+                writer.writerow(row)
+        messagebox.showinfo('Sukces', f'Zapisano mapping w {filename}')
+        logger.info('Mapping saved')
+        self.top.destroy()
+
+if __name__ == '__main__':
+    app = SampleMapperGenerator()
+    app.run()


### PR DESCRIPTION
## Summary
- add modular GUI apps for sample mapping, data assignment, generation and analysis
- integrate modules in a menu in `main.py`
- log all actions to `logs/program.log`
- include a simple plotting GUI
- document usage in README

## Testing
- `python3 -m py_compile logger_setup.py sample_mapper_generator.py mappings_assigner.py data_generator.py data_analyser.py interactive_plot_selector.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68400e83000c832aad9c0753fd4fa484